### PR TITLE
Fix tickadvance not resetting to tr0 on the server side

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ discombobulator_version=1.3-SNAPSHOT
 
 # mod
 mod_name=LoTAS-Light
-mod_version=1.1.0
+mod_version=1.1.1
 maven_group=com.mincecrafttas

--- a/src/main/java/com/minecrafttas/lotas_light/mixin/MixinTickRateManager.java
+++ b/src/main/java/com/minecrafttas/lotas_light/mixin/MixinTickRateManager.java
@@ -102,7 +102,6 @@ public abstract class MixinTickRateManager implements Tickratechanger {
 			if (tickrate == 0)
 				setTickRate(tickrateSaved);
 		}
-
 	}
 
 	@Override
@@ -132,7 +131,7 @@ public abstract class MixinTickRateManager implements Tickratechanger {
 
 	@Inject(method = "tick", at = @At("RETURN"))
 	public void inject_Tick(CallbackInfo ci) {
-		if (advanceTickrateServer) {
+		if (advanceTickrateServer || advanceTickrateClient) {
 			if (isServer())
 				this.advanceTickrateServer = false;
 			else

--- a/src/main/java/com/minecrafttas/lotas_light/mixin/MixinTickRateManager.java
+++ b/src/main/java/com/minecrafttas/lotas_light/mixin/MixinTickRateManager.java
@@ -29,7 +29,10 @@ import net.minecraft.world.TickRateManager;
 public abstract class MixinTickRateManager implements Tickratechanger {
 	@Unique
 	private static float tickrateSaved = 20;
-	private boolean advanceTickrate;
+	@Unique
+	private boolean advanceTickrateServer;
+	@Unique
+	private boolean advanceTickrateClient;
 	@Unique
 	private boolean isDisconnecting;
 
@@ -79,7 +82,8 @@ public abstract class MixinTickRateManager implements Tickratechanger {
 
 	@Override
 	public void toggleTickrate0() {
-		advanceTickrate = false;
+		advanceTickrateServer = false;
+		advanceTickrateClient = false;
 		if (tickrate == 0) {
 			setTickRate(tickrateSaved);
 		} else {
@@ -89,7 +93,8 @@ public abstract class MixinTickRateManager implements Tickratechanger {
 
 	@Override
 	public void enableTickrate0(boolean enable) {
-		advanceTickrate = false;
+		advanceTickrateServer = false;
+		advanceTickrateClient = false;
 		if (enable) {
 			if (tickrate != 0)
 				setTickRate(0f);
@@ -104,13 +109,16 @@ public abstract class MixinTickRateManager implements Tickratechanger {
 	public void advanceTick() {
 		if (tickrate == 0) {
 			setTickRate(tickrateSaved);
-			this.advanceTickrate = true;
+			if (isServer())
+				this.advanceTickrateServer = true;
+			else
+				this.advanceTickrateClient = true;
 		}
 	}
 
 	@Override
 	public boolean isAdvanceTick() {
-		return advanceTickrate;
+		return advanceTickrateServer || advanceTickrateClient;
 	}
 
 	@Override
@@ -124,8 +132,11 @@ public abstract class MixinTickRateManager implements Tickratechanger {
 
 	@Inject(method = "tick", at = @At("RETURN"))
 	public void inject_Tick(CallbackInfo ci) {
-		if (advanceTickrate && !(((TickRateManager) (Object) this) instanceof ServerTickRateManager)) {
-			this.advanceTickrate = false;
+		if (advanceTickrateServer) {
+			if (isServer())
+				this.advanceTickrateServer = false;
+			else
+				this.advanceTickrateClient = false;
 			setTickRate(0);
 		}
 	}
@@ -149,6 +160,10 @@ public abstract class MixinTickRateManager implements Tickratechanger {
 		long time = System.currentTimeMillis() - timeSinceTC - timeOffset;
 		time *= (tickrate / 20F);
 		return (long) (fakeTimeSinceTC + time);
+	}
+
+	private boolean isServer() {
+		return ((TickRateManager) (Object) this) instanceof ServerTickRateManager;
 	}
 
 	@Shadow


### PR DESCRIPTION
Hacky fix for tickadvance not working on the server side...
Slowly getting more and more dissatisfied with Mojang's tickratechanger
Maybe throwing that out in the future, who knows