### PR TITLE
Make savestates independent from the folder name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ discombobulator_version=1.3-SNAPSHOT
 
 # mod
 mod_name=LoTAS-Light
-mod_version=1.2.0-SNAPSHOT
+mod_version=1.2.0
 maven_group=com.mincecrafttas

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ discombobulator_version=1.3-SNAPSHOT
 
 # mod
 mod_name=LoTAS-Light
-mod_version=1.1.1
+mod_version=1.2.0-SNAPSHOT
 maven_group=com.mincecrafttas

--- a/src/main/java/com/minecrafttas/lotas_light/command/SavestateCommand.java
+++ b/src/main/java/com/minecrafttas/lotas_light/command/SavestateCommand.java
@@ -31,6 +31,8 @@ import net.minecraft.network.chat.Style;
 import net.minecraft.server.level.ServerLevel;
 
 public class SavestateCommand {
+	
+	public static boolean once = true;
 
 	public static void register(CommandDispatcher<CommandSourceStack> commandDispatcher) {
 		//@formatter:off
@@ -354,6 +356,7 @@ public class SavestateCommand {
 	}
 
 	private static int reload(CommandContext<CommandSourceStack> context) {
+		once = true;
 		context.getSource().sendSuccess(() -> Component.translatable("msg.lotaslight.savestate.reload").withStyle(ChatFormatting.GREEN), true);
 		LoTASLight.savestateHandler.reload();
 		return 0;
@@ -425,6 +428,7 @@ public class SavestateCommand {
 	private static void showInfo(CommandContext<CommandSourceStack> context, Integer indexToDisplay, Integer amount) {
 
 		int currentIndex = LoTASLight.savestateHandler.getCurrentIndex();
+		int size = LoTASLight.savestateHandler.size();
 		if (indexToDisplay == null) {
 			indexToDisplay = currentIndex;
 		}
@@ -433,10 +437,17 @@ public class SavestateCommand {
 		}
 
 		context.getSource().sendSystemMessage(Component.literal("")); // Print an empty line
+
 		String format = I18n.get("msg.lotaslight.savestate.dateformat");
 		SimpleDateFormat dateFormat = new SimpleDateFormat(format);
-
+		
 		List<Savestate> savestateList = LoTASLight.savestateHandler.getSavestateInfo(indexToDisplay, amount);
+		
+		if(savestateList.size() < size && once) {
+			context.getSource().sendSystemMessage(Component.translatable("gui.lotaslight.savestate.omitted", "/savestate info all").withStyle(ChatFormatting.RED, ChatFormatting.ITALIC));
+			once = false;
+		}
+		
 		for (Savestate savestate : savestateList) {
 
 			String index = savestate.getIndex() == null ? "" : Integer.toString(savestate.getIndex());

--- a/src/main/java/com/minecrafttas/lotas_light/savestates/SavestateHandler.java
+++ b/src/main/java/com/minecrafttas/lotas_light/savestates/SavestateHandler.java
@@ -262,6 +262,10 @@ public class SavestateHandler {
 	public List<SavestateIndexer.Savestate> getSavestateInfo(int index, int amount) {
 		return indexer.getSavestateList(index, amount);
 	}
+	
+	public int size() {
+		return indexer.size();
+	}
 
 	@FunctionalInterface
 	public interface SavestateCallback {

--- a/src/main/java/com/minecrafttas/lotas_light/savestates/SavestateIndexer.java
+++ b/src/main/java/com/minecrafttas/lotas_light/savestates/SavestateIndexer.java
@@ -92,6 +92,7 @@ public class SavestateIndexer {
 		currentSavestate.index = index;
 		currentSavestate.name = name;
 		currentSavestate.date = new Date();
+		currentSavestate.motion = motion;
 
 		currentSavestate.saveToXML();
 
@@ -126,9 +127,9 @@ public class SavestateIndexer {
 		}
 
 		int savedIndex = currentSavestate.index;
-		this.currentSavestate = savestateToLoad.clone();
+		this.currentSavestate = savestateToLoad.clone(savesDir.resolve(worldname).resolve(savestateDatPath), savesDir.resolve(worldname));
 
-		Path sourceDir = currentSavestate.getFolder();
+		Path sourceDir = savestateToLoad.getFolder();
 		Path targetDir = savesDir.resolve(worldname);
 
 		if (sourceDir != null && !Files.exists(sourceDir)) {

--- a/src/main/resources/assets/lotaslight/lang/en_us.json
+++ b/src/main/resources/assets/lotaslight/lang/en_us.json
@@ -45,5 +45,6 @@
 	"gui.lotaslight.savestate.load.name":"Loadstate screen",
 	"gui.lotaslight.savestate.load.start":"Loading a savestate, please wait",
 	"gui.lotaslight.savestate.load.end":"Loaded savestate %s from index %s",
-	"gui.lotaslight.savestate.button.closegui":"Close"
+	"gui.lotaslight.savestate.button.closegui":"Close",
+	"gui.lotaslight.savestate.omitted":"Some savestates are omitted. \"%s\" to show them all"
 }


### PR DESCRIPTION
Savestates in the `worldname-Savestates` folder were still technically expecting a certain name format...  
This PR makes it so the only requirement for savestates to be recognised is
1. The folder has to be in the `worldname-Savestates` folder
2. The savestate has to contain a `tas/savestate.xml`

## Renaming the savestate name
For ease of use, I decided that savestate folders should be named worldname1, worldname2, so that loading a backup is relatively easy, as you just have to remove the number from the name...

This broke compatibility with LoTAS a bit and was quite confusing to explain, so I decided to rename it back to worldname-Savestate1 like in LoTAS...
Together with the independent folder name, this change doesn't break existing projects

## More hints
`/savestate info` will now tell you, that some savestates are ommitted... By default, it shows the next and previous 5 savestates around the current index...

So if you have 15 savestates and you are on index 6 you will see savestates ~1-11. If that happens, a new message will appear in chat