### PR TITLE
Update preprocessor

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,10 @@ loader_version=0.16.10
 loom_version=1.10-SNAPSHOT
 
 # preprocessor
-discombobulator_version=1.3
+discombobulator_version=1.3.1
 
 # mod
 mod_name=LoTAS-Light
-mod_version=1.2.0
+mod_version=1.2.1
 maven_group=com.minecrafttas
 release=false


### PR DESCRIPTION
It just so happens that the potion and stream indicator are not showing because disco fails to copy the files while building. And that **only on Linux!** So the lovely github runner, who builds the mod and just so happens to run on linux, can't copy the textures and it leads to a mod without textures... Great!