### PR TITLE
Add Item Duplication

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,6 @@ discombobulator_version=1.3.1
 
 # mod
 mod_name=LoTAS-Light
-mod_version=1.2.2
+mod_version=1.3
 maven_group=com.minecrafttas
 release=false

--- a/src/main/java/com/minecrafttas/lotas_light/LoTASLightClient.java
+++ b/src/main/java/com/minecrafttas/lotas_light/LoTASLightClient.java
@@ -26,6 +26,12 @@ import net.minecraft.ChatFormatting;
 //# end
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
+//# 1.20.6
+//$$import net.minecraft.client.gui.screens.GenericMessageScreen;
+//# def
+import net.minecraft.client.gui.screens.GenericDirtMessageScreen;
+//# end
+import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.client.server.IntegratedServer;
@@ -57,6 +63,7 @@ public class LoTASLightClient implements ClientModInitializer {
 	public static Configuration config;
 	private boolean showHint = true;
 	private boolean showTickIndicator;
+	public static boolean dupe;
 
 	@Override
 	public void onInitializeClient() {
@@ -88,6 +95,7 @@ public class LoTASLightClient implements ClientModInitializer {
 		keybindManager.registerKeybind(new Keybind("key.lotaslight.advanceTickrate", "keycategory.lotaslight.lotaslight", GLFW.GLFW_KEY_F9, this::advanceTickrate, KeybindManager::isKeyDown));
 		keybindManager.registerKeybind(new Keybind("key.lotaslight.savestate", "keycategory.lotaslight.lotaslight", GLFW.GLFW_KEY_J, this::savestate));
 		keybindManager.registerKeybind(new Keybind("key.lotaslight.loadstate", "keycategory.lotaslight.lotaslight", GLFW.GLFW_KEY_K, this::loadstate));
+		keybindManager.registerKeybind(new Keybind("key.lotaslight.duping", "keycategory.lotaslight.lotaslight", GLFW.GLFW_KEY_O, this::dupe));
 
 		EventClientGameLoop.EVENT.register(keybindManager::onRunClientGameLoop);
 	}
@@ -349,6 +357,22 @@ public class LoTASLightClient implements ClientModInitializer {
 			LoTASLight.savestateHandler.resetState();
 			Minecraft.getInstance().setScreen(null);
 		}
+	}
+
+	private void dupe(Minecraft mc) {
+		dupe = true;
+		//# 1.21.7
+//$$		mc.level.disconnect(Component.translatable("gui.lotaslight.dupe.quitmsg"));
+		//# def
+		mc.level.disconnect();
+		//# end
+
+		//# 1.20.6
+//$$		mc.disconnect(new GenericMessageScreen(Component.translatable("gui.lotaslight.duping.quitmsg")), false);
+		//# def
+		mc.disconnect(new GenericDirtMessageScreen(Component.translatable("gui.lotaslight.duping.quitmsg")));
+		//# end
+		mc.setScreen(new TitleScreen());
 	}
 
 	private short findClosestRateIndex(float tickrate) {

--- a/src/main/java/com/minecrafttas/lotas_light/mixin/MixinMinecraftServer.java
+++ b/src/main/java/com/minecrafttas/lotas_light/mixin/MixinMinecraftServer.java
@@ -9,11 +9,19 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.minecrafttas.lotas_light.LoTASLightClient;
 import com.minecrafttas.lotas_light.duck.Tickratechanger;
 
 import net.minecraft.Util;
+import net.minecraft.client.server.IntegratedServer;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerTickRateManager;
+import net.minecraft.world.level.storage.LevelStorageSource;
+import net.minecraft.world.level.storage.WorldData;
 
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {
@@ -74,5 +82,14 @@ public class MixinMinecraftServer {
 	public void inject_stopServer(CallbackInfo ci) {
 		Tickratechanger tickrateManager = (Tickratechanger) ((MinecraftServer) (Object) this).tickRateManager();
 		tickrateManager.disconnect();
+	}
+	
+	@WrapOperation(method = "saveAllChunks", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess;saveDataTag(Lnet/minecraft/core/RegistryAccess;Lnet/minecraft/world/level/storage/WorldData;Lnet/minecraft/nbt/CompoundTag;)V"))
+	public void wrap_saveDataTag(LevelStorageSource.LevelStorageAccess instance, RegistryAccess access, WorldData data, CompoundTag singlePlayerTag, Operation<Void> original) {
+		if((MinecraftServer)(Object)this instanceof IntegratedServer && LoTASLightClient.dupe) {
+			LoTASLightClient.dupe = false;
+		} else {
+			original.call(instance, access, data, singlePlayerTag);
+		}
 	}
 }

--- a/src/main/resources/assets/lotaslight/lang/en_us.json
+++ b/src/main/resources/assets/lotaslight/lang/en_us.json
@@ -6,6 +6,7 @@
 	"key.lotaslight.advanceTickrate":"Advance Tick",
 	"key.lotaslight.savestate":"Savestate",
 	"key.lotaslight.loadstate":"Loadstate",
+	"key.lotaslight.duping":"Duplicate Items",
 	"msg.lotaslight.setTickrate":"Set the tickrate to %s",
 	"msg.lotaslight.turnOff":"To turn off these messages, use /lotaslight trc_showMessage false",
 	"msg.lotaslight.showmsg.true":"Tickrate messages enabled",
@@ -46,5 +47,6 @@
 	"gui.lotaslight.savestate.load.start":"Loading a savestate, please wait",
 	"gui.lotaslight.savestate.load.end":"Loaded savestate %s from index %s",
 	"gui.lotaslight.savestate.button.closegui":"Close",
-	"gui.lotaslight.savestate.omitted":"Some savestates are omitted. \"%s\" to show them all"
+	"gui.lotaslight.savestate.omitted":"Some savestates are omitted. \"%s\" to show them all",
+	"gui.lotaslight.duping.quitmsg":"Duping your items!"
 }


### PR DESCRIPTION
Reintroduces Dupemod from LoTAS with a new workflow:
1. Press Pause to save the game
2. Throw item out of your inventory/put in chest
3. Press "O"
4. Rejoin the world

This new workflow is a compromise between accuracy and speed. While the old LoTAS Dupemod was very fast to use, it was also the most inaccurate, as skipping the loading screen brought a slight difference to vanilla duping. And on the other side is said vanilla duping which is just slow and tedious but of course, the most accurate.

When pressing O, the mod disconnects the player to the main menu, but does not save the level.dat, which recreates the Alt+F4 and Task Manager duping.